### PR TITLE
Do not send codes to locked users

### DIFF
--- a/lib/two_factor_authentication/hooks/two_factor_authenticatable.rb
+++ b/lib/two_factor_authentication/hooks/two_factor_authenticatable.rb
@@ -10,7 +10,7 @@ Warden::Manager.after_authentication do |user, auth, options|
   end
 
   if user.respond_to?(:need_two_factor_authentication?) && !bypass_by_cookie
-    if auth.session(options[:scope])[TwoFactorAuthentication::NEED_AUTHENTICATION] = user.need_two_factor_authentication?(auth.request)
+    if (auth.session(options[:scope])[TwoFactorAuthentication::NEED_AUTHENTICATION] = user.need_two_factor_authentication?(auth.request)) && !user.max_login_attempts?
       user.send_two_factor_authentication_code
     end
   end


### PR DESCRIPTION
Currently, if a locked user tries to log in again, a code is sent although the user can't enter it.
